### PR TITLE
Refactor theme handling for dark mode

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/rjkroege/edwood/theme"
 	"image"
 	"log"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"9fans.net/go/plumb"
 	"github.com/rjkroege/edwood/draw"
 	"github.com/rjkroege/edwood/dumpfile"
+	"github.com/rjkroege/edwood/theme"
 )
 
 var (
@@ -32,7 +32,7 @@ var (
 	winsize           = flag.String("W", "1024x768", "Window size and position as WidthxHeight[@X,Y]")
 	ncol              = flag.Int("c", 2, "Number of columns at startup")
 	loadfile          = flag.String("l", "", "Load state from file generated with Dump command")
-	darkMode          = flag.Bool("v", false, "Enable dark (Vampira) mode colour scheme") // Added dark mode flag
+	darkFlag          = flag.Bool("dark", false, "Enable dark mode colour scheme")
 )
 
 func predrawInit() *dumpfile.Content {
@@ -169,7 +169,7 @@ func main() {
 		}
 
 		// Set dark mode state in theme package with display
-		theme.SetDarkMode(*darkMode, display)
+		theme.SetDarkMode(*darkFlag)
 		mainWithDisplay(global, dump, display)
 	})
 }

--- a/frame/draw.go
+++ b/frame/draw.go
@@ -4,7 +4,6 @@ import (
 	"image"
 
 	"github.com/rjkroege/edwood/draw"
-	"github.com/rjkroege/edwood/theme"
 )
 
 func (f *frameimpl) drawtext(pt image.Point, text draw.Image, back draw.Image) {
@@ -215,19 +214,16 @@ func (f *frameimpl) tick(pt image.Point, ticked bool) {
 		r.Max.X = f.rect.Max.X
 	}
 
-	// Determine the correct tick color based on dark mode
-	var tickColor draw.Image
-	if theme.IsDarkMode() {
-		tickColor = theme.TickColor // Use white tick for dark mode
-	} else {
-		tickColor = f.display.Black() // Use black tick for light mode
+	tickColor := f.tickcolor
+	if tickColor == nil {
+		tickColor = f.display.Black()
 	}
 
 	if ticked {
 		f.tickback.Draw(f.tickback.R(), f.background, nil, pt)
 		f.background.Draw(r, tickColor, f.tickimage, image.Point{}) // draws an alpha-blended box
 	} else {
-		// Restore the background when removing the tick
+		// There is an issue with tick management
 		f.background.Draw(r, f.tickback, nil, image.Point{})
 	}
 	f.ticked = ticked

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -285,6 +285,7 @@ type frameimpl struct {
 	tickback    draw.Image // image under tick
 	ticked      bool       // Is the tick on.
 	highlighton bool       // True if the highlight is painted.
+	tickcolor   draw.Image // colour of the tick
 
 	// Set this to true to indicate that the Frame should not emit drawing ops.
 	// Use this if the Frame is being used "headless" to measure some text.
@@ -294,9 +295,9 @@ type frameimpl struct {
 
 // NewFrame creates a new Frame with Font ft, background image b, colours cols, and
 // of the size r
-func NewFrame(r image.Rectangle, ft draw.Font, b draw.Image, cols [NumColours]draw.Image) Frame {
+func NewFrame(r image.Rectangle, ft draw.Font, b draw.Image, cols [NumColours]draw.Image, tick draw.Image) Frame {
 	f := new(frameimpl)
-	f.Init(r, OptColors(cols), OptFont(ft), OptBackground(b), OptMaxTab(8))
+	f.Init(r, OptColors(cols), OptFont(ft), OptBackground(b), OptMaxTab(8), OptTickColor(tick))
 	return f
 }
 

--- a/frame/frameopts.go
+++ b/frame/frameopts.go
@@ -67,6 +67,13 @@ func OptMaxTab(maxtabchars int) OptionClosure {
 	}
 }
 
+// OptTickColor sets the tick colour image used when drawing the cursor.
+func OptTickColor(col draw.Image) OptionClosure {
+	return func(f *frameimpl, ctx *optioncontext) {
+		f.tickcolor = col
+	}
+}
+
 // computemaxtab returns the new ftw value
 func (ctx *optioncontext) computemaxtab(maxtab, ftw int) int {
 	if ctx.maxtabchars < 0 {

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -208,7 +208,7 @@ func setupFrame(t *testing.T, iv *invariants) Frame {
 	if err != nil {
 		t.Fatalf("can't make mock font %q: %v", name, err)
 	}
-	fr := NewFrame(iv.textarea, font, display.ScreenImage(), textcolors)
+	fr := NewFrame(iv.textarea, font, display.ScreenImage(), textcolors, nil)
 
 	return fr
 }

--- a/frame/tick.go
+++ b/frame/tick.go
@@ -1,18 +1,13 @@
 package frame
 
 import (
-	"github.com/rjkroege/edwood/draw"
-	"github.com/rjkroege/edwood/theme"
 	"image"
 	"log"
+
+	"github.com/rjkroege/edwood/draw"
 )
 
-// drawTick is a centralised function to render a tick with consistent logic.
-func (f *frameimpl) drawTick(target draw.Image, tickColor draw.Image, rect image.Rectangle) {
-	target.Draw(rect, tickColor, nil, image.Point{})
-}
-
-// InitTick initialises the tick with consistent dark mode logic.
+// InitTick initialises the tick used to show the insertion point.
 // TODO(rjk): doesn't appear to need to be exposed publically.
 func (f *frameimpl) InitTick() {
 	if f.cols[ColBack] == nil || f.display == nil {
@@ -38,14 +33,7 @@ func (f *frameimpl) InitTick() {
 		return
 	}
 
-	var backgroundColor draw.Color
-	if theme.IsDarkMode() {
-		backgroundColor = theme.BackgroundColor
-	} else {
-		backgroundColor = theme.White
-	}
-
-	f.tickback, err = f.display.AllocImage(f.tickimage.R(), b.Pix(), false, backgroundColor)
+	f.tickback, err = f.display.AllocImage(f.tickimage.R(), b.Pix(), false, draw.Transparent)
 	if err != nil {
 		log.Printf("InitTick: Failed to allocate tickback image: %v\n", err)
 		f.tickimage.Free()
@@ -63,11 +51,4 @@ func (f *frameimpl) InitTick() {
 	// box on each end
 	f.tickimage.Draw(image.Rect(0, 0, f.tickscale*frtickw, f.tickscale*frtickw), f.display.Opaque(), nil, image.Pt(0, 0))
 	f.tickimage.Draw(image.Rect(0, height-f.tickscale*frtickw, f.tickscale*frtickw, height), f.display.Opaque(), nil, image.Pt(0, 0))
-
-	// Flush the display buffer to ensure it's drawn
-	err = f.display.Flush()
-	if err != nil {
-		log.Printf("InitTick: Failed to flush display: %v\n", err)
-		f.tickimage = nil // Disable the tick functionality to avoid issues
-	}
 }

--- a/globals.go
+++ b/globals.go
@@ -30,6 +30,7 @@ type globals struct {
 	button    draw.Image
 	but2col   draw.Image
 	but3col   draw.Image
+	tickcol   draw.Image
 
 	//	boxcursor Cursor
 	row Row
@@ -155,20 +156,12 @@ func (g *globals) iconinit(display draw.Display) {
 	r.Max.X -= display.ScaleSize(ButtonBorder)
 	g.modbutton.Border(r, display.ScaleSize(ButtonBorder), g.tagcolors[frame.ColBord], image.Point{})
 	r = r.Inset(display.ScaleSize(ButtonBorder))
-	if *darkMode {
-		tmp, _ := display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, theme.ModButton)
-		g.modbutton.Draw(r, tmp, nil, image.Point{})
-	} else {
-		tmp, _ := display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Medblue)
-		g.modbutton.Draw(r, tmp, nil, image.Point{})
-	}
+	p := theme.Current()
+	tmp, _ := display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.ModButton)
+	g.modbutton.Draw(r, tmp, nil, image.Point{})
 
 	r = g.button.R()
-	if *darkMode {
-		g.colbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, theme.ColButton)
-	} else {
-		g.colbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, draw.Purpleblue)
-	}
+	g.colbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, p.ColButton)
 
 	// These are the highlight colors for mouse buttons 2 and 3 functions
 	g.but2col, _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, 0xAA0000FF)
@@ -176,38 +169,27 @@ func (g *globals) iconinit(display draw.Display) {
 }
 
 func (g *globals) applyMode(display draw.Display) {
-	if *darkMode {
-		// Apply dark mode colours
-		g.tagcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, theme.TagColBack)
-		g.tagcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, theme.TagColHigh)
-		g.tagcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, theme.TagColBord)
-		g.tagcolors[frame.ColText] = display.White()
-		g.tagcolors[frame.ColHText] = display.White()
+	p := theme.Current()
 
-		g.textcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, theme.TextColBack)
-		g.textcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, theme.TextColHigh)
-		g.textcolors[frame.ColText] = display.White()
-		g.textcolors[frame.ColHText] = display.White()
+	g.tagcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColBack)
+	g.tagcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColHigh)
+	g.tagcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColBord)
+	g.tagcolors[frame.ColText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColText)
+	g.tagcolors[frame.ColHText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagHText)
 
-		r := image.Rect(0, 0, display.ScaleSize(Scrollwid+ButtonBorder), fontget(g.tagfont, display).Height()+1)
-		g.colbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, 0xAA0000FF)
+	g.textcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColBack)
+	g.textcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColHigh)
+	g.textcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColBord)
+	g.textcolors[frame.ColText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColText)
+	g.textcolors[frame.ColHText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColHText)
 
-		// These are the highlight colors for mouse buttons 2 and 3 functions
-		g.but2col, _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, 0xAA0000FF)
-		g.but3col, _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, 0x006600FF)
+	r := image.Rect(0, 0, display.ScaleSize(Scrollwid+ButtonBorder), fontget(g.tagfont, display).Height()+1)
+	g.colbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, p.ColButton)
 
-	} else {
-		// Apply light mode colours (default)
-		g.tagcolors[frame.ColBack] = display.AllocImageMix(draw.Palebluegreen, draw.White)
-		g.tagcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Palegreygreen)
-		g.tagcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Purpleblue)
-		g.tagcolors[frame.ColText] = display.Black()
-		g.tagcolors[frame.ColHText] = display.Black()
+	g.modbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, p.ModButton)
 
-		g.textcolors[frame.ColBack] = display.AllocImageMix(draw.Paleyellow, draw.White)
-		g.textcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Darkyellow)
-		g.textcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Yellowgreen)
-		g.textcolors[frame.ColText] = display.Black()
-		g.textcolors[frame.ColHText] = display.Black()
-	}
+	g.tickcol, _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TickColor)
+
+	g.but2col, _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.But2Col)
+	g.but3col, _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.But3Col)
 }

--- a/text.go
+++ b/text.go
@@ -107,7 +107,7 @@ func (t *Text) Init(r image.Rectangle, rf string, cols [frame.NumColours]draw.Im
 	t.font = rf
 	t.tabstop = int(global.maxtab)
 	t.tabexpand = global.tabexpand
-	t.fr = frame.NewFrame(r, fontget(rf, t.display), t.display.ScreenImage(), cols)
+	t.fr = frame.NewFrame(r, fontget(rf, t.display), t.display.ScreenImage(), cols, global.tickcol)
 	t.Redraw(r, -1, false /* noredraw */)
 	return t
 }

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -2,158 +2,85 @@ package theme
 
 import (
 	"github.com/rjkroege/edwood/draw"
-	"image"
 )
 
-var darkMode bool
-
-// SetDarkMode sets the dark mode state and applies the appropriate colors
-func SetDarkMode(enabled bool, display draw.Display) {
-	darkMode = enabled
-	SetColorsForMode(darkMode, display)
-}
-
-// IsDarkMode returns the current dark mode state
-func IsDarkMode() bool {
-	return darkMode
+type Palette struct {
+	TagColBack   draw.Color
+	TagColHigh   draw.Color
+	TagColBord   draw.Color
+	TagColText   draw.Color
+	TagHText     draw.Color
+	TextColBack  draw.Color
+	TextColHigh  draw.Color
+	TextColBord  draw.Color
+	TextColText  draw.Color
+	TextColHText draw.Color
+	ModButton    draw.Color
+	ColButton    draw.Color
+	ButtonColor  draw.Color
+	But2Col      draw.Color
+	But3Col      draw.Color
+	Background   draw.Color
+	TickColor    draw.Color
 }
 
 var (
-	Black         draw.Color
-	Darkyellow    draw.Color
-	Medblue       draw.Color
-	Nofill        draw.Color
-	Notacolor     draw.Color
-	Opaque        draw.Color
-	Palebluegreen draw.Color
-	Palegreygreen draw.Color
-	Paleyellow    draw.Color
-	Purpleblue    draw.Color
-	Transparent   draw.Color
-	White         draw.Color
-	Yellowgreen   draw.Color
-
-	BackgroundColor draw.Color
-
-	TickColor  draw.Image // Now this is not a pointer but an interface
-	TagColBack draw.Color
-	TagColHigh draw.Color
-
-	TagColBord draw.Color
-	TagColText draw.Color
-	TagHText   draw.Color
-
-	TextColBack  draw.Color // The text backgrounds
-	TextColHigh  draw.Color // The text highlight
-	TextColBord  draw.Color // The scroll bar background borders
-	TextColText  draw.Color // The text
-	TextColHText draw.Color // The color of the text when highlighted
-
-	ModButton draw.Color
-	ColButton draw.Color
-
-	ButtonColor draw.Color
-	But2Col     draw.Color
-	But3Col     draw.Color
-
-	KeyCmd      rune = draw.KeyCmd
-	KeyDown     rune = draw.KeyDown
-	KeyEnd      rune = draw.KeyEnd
-	KeyHome     rune = draw.KeyHome
-	KeyInsert   rune = draw.KeyInsert
-	KeyLeft     rune = draw.KeyLeft
-	KeyPageDown rune = draw.KeyPageDown
-	KeyPageUp   rune = draw.KeyPageUp
-	KeyRight    rune = draw.KeyRight
-	KeyUp       rune = draw.KeyUp
+	darkMode bool
+	current  Palette
 )
 
-// SetColorsForMode sets colors based on the mode (dark or light)
-func SetColorsForMode(isDarkMode bool, display draw.Display) {
-	if isDarkMode {
-		// Define colors for dark mode
-		Black = draw.Black
-		Darkyellow = 0x6665A8FF
-		Medblue = 0xFFFF6DFF
-		Nofill = draw.Nofill
-		Notacolor = draw.Notacolor
-		Palebluegreen = 0x110100FF
-		Palegreygreen = draw.Palegreygreen
-		Paleyellow = 0x000013FF
-		Purpleblue = 0x777738FF
-		Transparent = draw.Transparent
-		White = draw.White
-		Yellowgreen = 0x6665A8FF
+var lightPalette = Palette{
+	TagColBack:   0xE0E0E0FF,
+	TagColHigh:   0xC0C0C0FF,
+	TagColBord:   0x888888FF,
+	TagColText:   draw.Black,
+	TagHText:     draw.Black,
+	TextColBack:  0xFFFFFFFF,
+	TextColHigh:  0xFFFF00FF,
+	TextColBord:  0x888888FF,
+	TextColText:  draw.Black,
+	TextColHText: draw.Black,
+	ModButton:    0x222222FF,
+	ColButton:    0x666666FF,
+	ButtonColor:  draw.Black,
+	But2Col:      0xAA0000FF,
+	But3Col:      0x006600FF,
+	Background:   draw.White,
+	TickColor:    draw.Palegreygreen,
+}
 
-		TagColBack = 0x333333FF // The tagcolumn background
-		TagColHigh = 0x888888FF // The tagcolumn highlight
+var darkPalette = Palette{
+	TagColBack:   0x333333FF,
+	TagColHigh:   0x888888FF,
+	TagColBord:   0x888888FF,
+	TagColText:   0xEEEEEEFF,
+	TagHText:     0xEEEEEEFF,
+	TextColBack:  0x222222FF,
+	TextColHigh:  0x444444FF,
+	TextColBord:  0x888888FF,
+	TextColText:  0xEEEEEEFF,
+	TextColHText: 0xEEEEEEFF,
+	ModButton:    0x666666FF,
+	ColButton:    0x666666FF,
+	ButtonColor:  draw.White,
+	But2Col:      0xAA0000FF,
+	But3Col:      0x006600FF,
+	Background:   draw.Black,
+	TickColor:    draw.White,
+}
 
-		TagColBord = 0x888888FF // The tagcolumn border
-		TagColText = 0xEEEEEEFF // The tagcolumn text
-		TagHText = 0xEEEEEEFF   // The tagcolumn text when highlighted
-
-		TextColBack = 0x222222FF  // The text backgrounds
-		TextColHigh = 0x444444FF  // The text highlight
-		TextColBord = 0x888888FF  // The scroll bar background borders
-		TextColText = 0xEEEEEEFF  // The text
-		TextColHText = 0xEEEEEEFF // The color of the text when highlighted
-
-		BackgroundColor = draw.Black
-
-		ModButton = 0x666666FF // The color of the file-modified button
-		ColButton = 0x666666FF // The color of the file-colour button
-
-		ButtonColor = draw.White // The color of the mouse buttons
-		But2Col = 0xAA0000FF     // The color of the mouse button 2 functions
-		But3Col = 0x006600FF     // The color of the mouse button 3 functions
+// SetDarkMode selects between the light and dark palettes.
+func SetDarkMode(enabled bool) {
+	darkMode = enabled
+	if enabled {
+		current = darkPalette
 	} else {
-		// Define colors for light mode (default)
-		Darkyellow = draw.Darkyellow
-		Medblue = draw.Medblue
-		Nofill = draw.Nofill
-		Notacolor = draw.Notacolor
-		Palebluegreen = draw.Palebluegreen
-		Palegreygreen = draw.Palegreygreen
-		Paleyellow = draw.Paleyellow
-		Purpleblue = draw.Purpleblue
-		Transparent = draw.Transparent
-		White = draw.White
-		Yellowgreen = draw.Yellowgreen
-		Black = draw.Black
-
-		TagColBack = 0xE0E0E0FF // The tagcolumn background
-		TagColHigh = 0xC0C0C0FF // The tagcolumn highlight
-
-		TagColBord = 0x888888FF // The tagcolumn border
-		TagColText = draw.Black // The tagcolumn text
-		TagHText = draw.Black   // The tagcolumn text when highlighted
-
-		TextColBack = 0xFFFFFFFF  // The text backgrounds
-		TextColHigh = 0xFFFF00FF  // The text highlight
-		TextColBord = 0x888888FF  // The scroll bar background borders
-		TextColText = draw.Black  // The text
-		TextColHText = draw.Black // The color of the text when highlighted
-
-		ModButton = 0x222222FF // The color of the file-modified button
-		ColButton = 0x666666FF // The color of the file-colour button
-
-		ButtonColor = draw.Black // The color of the mouse buttons
-		But2Col = 0xAA0000FF     // The color of the mouse button 2 functions
-		But3Col = 0x006600FF     // The color of the mouse button 3 functions
-	}
-
-	// Access the ScreenImage method and AllocImage method directly
-	screenImage := display.ScreenImage() // This calls the method on the Display interface
-
-	// Allocate an Image for TickColor based on the mode
-	var err error
-	if isDarkMode {
-		TickColor, err = display.AllocImage(image.Rect(0, 0, 1, 1), screenImage.Pix(), true, draw.White)
-	} else {
-		TickColor, err = display.AllocImage(image.Rect(0, 0, 1, 1), screenImage.Pix(), true, draw.Palegreygreen)
-	}
-
-	if err != nil {
-		panic("Failed to allocate TickColor image: " + err.Error())
+		current = lightPalette
 	}
 }
+
+// IsDarkMode reports the current mode.
+func IsDarkMode() bool { return darkMode }
+
+// Current returns the active colour palette.
+func Current() Palette { return current }


### PR DESCRIPTION
## Summary
- restructure theme definitions into a `Palette` struct
- support setting dark mode with `SetDarkMode(bool)`
- update globals to use the palette
- pass tick colour into frames
- remove theme references from libframe
- rename dark mode flag to `-dark`

## Testing
- `go test ./...` *(fails: no route to host)*