### PR TITLE
Update light theme and color allocation

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -82,7 +82,11 @@ func mainWithDisplay(g *globals, dump *dumpfile.Content, display draw.Display) {
 	// Apply the appropriate mode based on the flag
 	g.applyMode(display)
 
-	display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.Point{})
+	if theme.IsDarkMode() {
+		display.ScreenImage().Draw(display.ScreenImage().R(), display.Black(), nil, image.Point{})
+	} else {
+		display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.Point{})
+	}
 
 	g.mousectl = display.InitMouse()
 	g.mouse = &g.mousectl.Mouse
@@ -238,7 +242,11 @@ func mousethread(g *globals, display draw.Display) {
 			if err := display.Attach(draw.Refnone); err != nil {
 				panic("failed to attach to window")
 			}
-			display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.Point{})
+			if theme.IsDarkMode() {
+				display.ScreenImage().Draw(display.ScreenImage().R(), display.Black(), nil, image.Point{})
+			} else {
+				display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.Point{})
+			}
 			// TODO(rjk): We appear to have already done this.
 			g.iconinit(display)
 			ScrlResize(display)

--- a/globals.go
+++ b/globals.go
@@ -130,18 +130,7 @@ func makeglobals() *globals {
 
 // TODO(rjk): Can separate this out even better.
 func (g *globals) iconinit(display draw.Display) {
-	if g.tagcolors[frame.ColBack] == nil {
-		g.tagcolors[frame.ColBack] = display.AllocImageMix(draw.Palebluegreen, draw.White)
-		g.tagcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Palegreygreen)
-		g.tagcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Purpleblue)
-		g.tagcolors[frame.ColText] = display.Black()
-		g.tagcolors[frame.ColHText] = display.Black()
-		g.textcolors[frame.ColBack] = display.AllocImageMix(draw.Paleyellow, draw.White)
-		g.textcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Darkyellow)
-		g.textcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Yellowgreen)
-		g.textcolors[frame.ColText] = display.Black()
-		g.textcolors[frame.ColHText] = display.Black()
-	}
+	// Colours are now initialised in applyMode.
 
 	// ...
 	r := image.Rect(0, 0, display.ScaleSize(Scrollwid+ButtonBorder), fontget(g.tagfont, display).Height()+1)
@@ -171,13 +160,21 @@ func (g *globals) iconinit(display draw.Display) {
 func (g *globals) applyMode(display draw.Display) {
 	p := theme.Current()
 
-	g.tagcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColBack)
+	if theme.IsDarkMode() {
+		g.tagcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColBack)
+	} else {
+		g.tagcolors[frame.ColBack] = display.AllocImageMix(p.TagColBack, draw.White)
+	}
 	g.tagcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColHigh)
 	g.tagcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColBord)
 	g.tagcolors[frame.ColText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagColText)
 	g.tagcolors[frame.ColHText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TagHText)
 
-	g.textcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColBack)
+	if theme.IsDarkMode() {
+		g.textcolors[frame.ColBack], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColBack)
+	} else {
+		g.textcolors[frame.ColBack] = display.AllocImageMix(p.TextColBack, draw.White)
+	}
 	g.textcolors[frame.ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColHigh)
 	g.textcolors[frame.ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColBord)
 	g.textcolors[frame.ColText], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, p.TextColText)

--- a/row.go
+++ b/row.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rjkroege/edwood/draw"
 	"github.com/rjkroege/edwood/dumpfile"
 	"github.com/rjkroege/edwood/file"
+	"github.com/rjkroege/edwood/theme"
 	"github.com/rjkroege/edwood/util"
 )
 
@@ -31,7 +32,11 @@ func (row *Row) Init(r image.Rectangle, dis draw.Display) *Row {
 		row = &Row{}
 	}
 	row.display = dis
-	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
+	if theme.IsDarkMode() {
+		row.display.ScreenImage().Draw(r, row.display.Black(), nil, image.Point{})
+	} else {
+		row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
+	}
 	row.col = []*Column{}
 	row.r = r
 	r1 := r

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -30,14 +30,15 @@ var (
 )
 
 var lightPalette = Palette{
-	TagColBack:   0xE0E0E0FF,
-	TagColHigh:   0xC0C0C0FF,
-	TagColBord:   0x888888FF,
+	// Plan 9 defaults
+	TagColBack:   draw.Palebluegreen,
+	TagColHigh:   draw.Palegreygreen,
+	TagColBord:   draw.Purpleblue,
 	TagColText:   draw.Black,
 	TagHText:     draw.Black,
-	TextColBack:  0xFFFFFFFF,
-	TextColHigh:  0xFFFF00FF,
-	TextColBord:  0x888888FF,
+	TextColBack:  draw.Paleyellow,
+	TextColHigh:  draw.Darkyellow,
+	TextColBord:  draw.Yellowgreen,
 	TextColText:  draw.Black,
 	TextColHText: draw.Black,
 	ModButton:    0x222222FF,
@@ -46,7 +47,7 @@ var lightPalette = Palette{
 	But2Col:      0xAA0000FF,
 	But3Col:      0x006600FF,
 	Background:   draw.White,
-	TickColor:    draw.Palegreygreen,
+	TickColor:    draw.Black,
 }
 
 var darkPalette = Palette{


### PR DESCRIPTION
## Summary
- adopt Plan 9 colours in `lightPalette`
- allocate mixed colours in `applyMode`
- remove legacy colour init from `iconinit`
- render the blank screen black in dark mode

## Testing
- `go test ./...` *(fails: no route to host)*